### PR TITLE
Stop Addresses and links of runs from being published

### DIFF
--- a/strava.go
+++ b/strava.go
@@ -61,29 +61,11 @@ func watchStrava(irc *goirc.Connection) {
 				continue
 			}
 			aDistance := activity.Distance / 1000
-			aLocation := ""
-			geocoder := google.Geocoder(cfg.Strava.GoogleAPIKey)
-			address, _ := geocoder.ReverseGeocode(activity.StartLocation[0], activity.StartLocation[1])
-			if address != "" {
-				// Most addresses have the town, zip code and country in the last 3 CSV components,
-				// but some like France or UK have it in the last 2
-				splitLoc := 3
-				if strings.HasSuffix(address, "France") || strings.HasSuffix(address, "UK") {
-					splitLoc = 2
-				}
-				addressComp := strings.Split(address, ",")
-				if len(addressComp) > splitLoc {
-					aLocation = " around" + strings.Join(addressComp[len(addressComp)-splitLoc:], ",")
-				} else {
-					aLocation = " around " + address
-				}
-			}
-			irc.Notice(irchan, fmt.Sprintf("%s %s went for a %0.1fkm %s%s strava.com/activities/%d",
+			irc.Notice(irchan, fmt.Sprintf("%s %s went for a %0.1fkm %s%s",
 				activity.Athlete.FirstName, activity.Athlete.LastName,
 				aDistance,
 				strings.ToLower(activity.Name),
-				aLocation,
-				activity.Id))
+				))
 		}
 		isFirstRun = false
 		time.Sleep(600 * time.Second)


### PR DESCRIPTION
The addresses of where people are running are being put into 
a public irc channel. In some countries the first part of a post code
can be a small as a couple miles. The Strava link has also been removed
as this is another area where peoples privacy can be compromised.